### PR TITLE
Update breeze.ajaxpost.js

### DIFF
--- a/breeze.ajaxpost.js
+++ b/breeze.ajaxpost.js
@@ -8,7 +8,7 @@
  * conditions of the IdeaBlade Breeze license, available at http://www.breezejs.com/license
  *
  * Author: Steve Schmidt
- * Version: 1.0.5
+ * Version: 1.0.6
  * 
  * Special parameters:
  *  $method: ‘POST’ or ‘GET’ (the default)


### PR DESCRIPTION
This change was required after upgrading to breeze 1.4.12, otherwise the ajax function call has the "this" keyword undefined inside the breeze library. For my understanding the "this" should be the ajaxAdapter.

Fault code in the breeze library is at line 14952:
  if (!core.isEmpty(this.defaultSettings)) {

Without this change, the "this" keyword is undefined on breeze 1.4.12 release, it was ok on 1.4.11 release.
