### PR TITLE
Added custom AJAX headers to the AJAX POST

### DIFF
--- a/breeze.ajaxpost.js
+++ b/breeze.ajaxpost.js
@@ -58,6 +58,8 @@
         }
 
         var ajaxFunction = ajaxAdapter.ajax;
+        // Grab the custom headers set on the ajax adapter
+        var customHeaders = ajaxAdapter.defaultSettings.headers;
         if (ajaxFunction) {
             ajaxAdapter.ajax = function (settings) {
                 processSettings(settings);
@@ -94,6 +96,14 @@
                     settings.params = null; 
                 }
             }
+        }
+        // If there are custom headers,
+        if (customHeaders) {
+            settings.headers = {  };
+            // Create each one on the headers object
+            $.each(customHeaders, function (index, item) {
+                settings.headers[index]= item;
+            });
         }
 
         return settings;


### PR DESCRIPTION
I saw the 1.14.11 branch of Breeze.js included the headers suggestion I made here - http://stackoverflow.com/questions/21268636/breeze-1-4-8-angular-ajax-adapter-how-to-customize-ajax-settings/21994687#21994687 - But I could not find the update to the ajax post file.
