### PR TITLE
Development/save error extensions queuing support

### DIFF
--- a/breeze.saveErrorExtensions.js
+++ b/breeze.saveErrorExtensions.js
@@ -71,6 +71,12 @@
 	function getErrorMessage(error) {
 		var msg = error.message;
 		var entityErrors = error.entityErrors;
+
+        // Save queuing wraps the error and has the concrete error in the innerError property.
+		if (!entityErrors && error.innerError) {
+		    entityErrors = error.innerError.entityErrors;
+        }
+
 		if (entityErrors && entityErrors.length) {
 			service.reviewServerErrors(entityErrors);
 			return getValidationMessages(entityErrors);

--- a/breeze.saveErrorExtensions.js
+++ b/breeze.saveErrorExtensions.js
@@ -72,10 +72,10 @@
 		var msg = error.message;
 		var entityErrors = error.entityErrors;
 
-        // Save queuing wraps the error and has the concrete error in the innerError property.
+		// Save queuing wraps the error and has the concrete error in the innerError property.
 		if (!entityErrors && error.innerError) {
 		    entityErrors = error.innerError.entityErrors;
-        }
+		}
 
 		if (entityErrors && entityErrors.length) {
 			service.reviewServerErrors(entityErrors);


### PR DESCRIPTION
If SaveQueuing is enabled and validation errors occur, they are not in the error.entityErrors property, but instead the error.innerError.entityErrors property. This PR extends the saveErrorExtensions script so that it displays the individual validation errors, even with SaveQueuing enabled.