### PR TITLE
Support for Kendo UI controls in breeze.directives

### DIFF
--- a/breeze.directives.js
+++ b/breeze.directives.js
@@ -102,10 +102,16 @@
         return directive;
 
         function link(scope, element, attrs) {
+            var modelPath = attrs.ngModel;
+            if (!modelPath) {
+                // Special handling for binding of Telerik Kendo UI controls
+                modelPath = attrs.kNgModel;
+            }
+
             // get validation info for bound element and entity property
             var info = validateInfo.create(
                 scope,
-                attrs.ngModel,
+                modelPath,
                 attrs.zValidate);
 
             if (!info.getValErrs) { return; } // can't do anything w/o this method


### PR DESCRIPTION
We're using Breeze together with Teleriks Kendo UI controls which use k-ng-model instead of ng-model for some controls. This PR enhances breeze.directives to also support controls which are bound with k-ng-model. 