### PR TITLE
Enable events correctly after saving

### DIFF
--- a/breeze.savequeuing.js
+++ b/breeze.savequeuing.js
@@ -323,8 +323,8 @@
     Event.enable('hasChangesChanged', manager, false);
 
     return function restorePublishing() {
-      Event.enable('entityChanged', manager, false);
-      Event.enable('hasChangesChanged', manager, false);
+      Event.enable('entityChanged', manager, true);
+      Event.enable('hasChangesChanged', manager, true);
     }
   }
 


### PR DESCRIPTION
This fixes an error in the save queuing script, where the `entityChanged` and `hasChangesChanged` events stayed disabled after an save.