### PR TITLE
When using the endpoints _api/Web/CurrentUser or _api/ does not have …

### DIFF
--- a/breeze.labs.dataservice.sharepoint.js
+++ b/breeze.labs.dataservice.sharepoint.js
@@ -357,7 +357,7 @@
         var data = response.data;
         var inlineCount = data.__count ? parseInt(data.__count, 10) : undefined;
         var rData = {
-          results: adapter._getResponseData(response).results,
+          results: adapter._getResponseData(response).results || adapter._getResponseData(response),
           inlineCount: inlineCount,
           httpResponse: response
         };


### PR DESCRIPTION
When using the endpoints _api/Web/CurrentUser or _api/ does not have a results element and Breeze returns an empty object. This allows for a fallback to return something. It has been tested with https://gist.github.com/wpsmith/a0bb85cee9a4f8885fde