### PR TITLE
allow zAppendTo directive

### DIFF
--- a/breeze.directives.js
+++ b/breeze.directives.js
@@ -123,7 +123,11 @@
                 var valTemplate = config.zValidateTemplate;
                 var requiredTemplate = config.zRequiredTemplate || '';
                 var decorator = angular.element('<span class="z-decorator"></span>');
-                element.after(decorator);
+                if (attrs.zAppendTo){
+                    angular.element(document.querySelector(attrs.zAppendTo)).append(decorator);
+                } else {
+                    element.after(decorator);
+                }
 
                 // unwrap bound elements
                 decorator = decorator[0];


### PR DESCRIPTION
 addresses issue #27 by allowing the z-decorator to be appended to elements aside from the input element being watched